### PR TITLE
Offchain worker support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8268,6 +8268,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "hex-literal",
+ "log",
  "node-primitives",
  "pallet-asset-tx-payment",
  "pallet-assets",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4740,6 +4740,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex",
  "log",
  "pallet-balances",
  "parity-scale-codec",

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -350,6 +350,14 @@ pub fn new_full_base(
 	));
 
 	if config.offchain_worker.enabled {
+		// TODO: use custom key here
+		sp_keystore::SyncCryptoStore::sr25519_generate_new(
+			&*keystore,
+			societal_node_runtime::pallet_dao::KEY_TYPE,
+			Some("//Alice"),
+		)
+		.expect("Creating key with account Alice should succeed.");
+
 		sc_service::build_offchain_workers(
 			&config,
 			task_manager.spawn_handle(),

--- a/pallets/dao-collective/src/lib.rs
+++ b/pallets/dao-collective/src/lib.rs
@@ -1212,10 +1212,6 @@ impl<T: Config<I>, I: 'static> ApprovePropose<DaoId, T::AccountId, T::Hash> for 
 		hash: T::Hash,
 		length_bound: u32,
 	) -> Result<(), DispatchError> {
-		log::info!("we are finally here at dao collective: {:?}", who);
-		log::info!("dao id: {:?}", dao_id);
-		log::info!("hash: {:?}", hash);
-
 		let proposal = <PendingProposalOf<T, I>>::get(dao_id, hash).expect("Proposal not found");
 
 		Self::do_propose_proposed(who, dao_id, threshold, Box::new(proposal), length_bound)?;

--- a/pallets/dao-collective/src/lib.rs
+++ b/pallets/dao-collective/src/lib.rs
@@ -50,7 +50,8 @@ use sp_runtime::{traits::Hash, RuntimeDebug};
 use sp_std::{marker::PhantomData, prelude::*, result, str};
 
 use dao_primitives::{
-	ApprovePropose, ChangeDaoMembers, DaoPolicy, DaoProvider, InitializeDaoMembers, PendingProposal,
+	ApprovePropose, ApproveVote, ChangeDaoMembers, DaoPolicy, DaoProvider, InitializeDaoMembers,
+	PendingProposal, PendingVote,
 };
 
 use frame_support::{
@@ -145,7 +146,7 @@ pub struct Votes<AccountId, BlockNumber> {
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use dao_primitives::{AccountTokenBalance, PendingProposal};
+	use dao_primitives::{AccountTokenBalance, PendingProposal, PendingVote};
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 
@@ -249,6 +250,19 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
+	/// Actual pending proposal for a given hash.
+	#[pallet::storage]
+	#[pallet::getter(fn pending_voting)]
+	pub type PendingVoting<T: Config<I>, I: 'static = ()> = StorageDoubleMap<
+		_,
+		Twox64Concat,
+		DaoId,
+		Identity,
+		T::Hash,
+		PendingVote<T::AccountId, T::Hash>,
+		OptionQuery,
+	>;
+
 	/// Proposals so far.
 	#[pallet::storage]
 	#[pallet::getter(fn proposal_count)]
@@ -279,6 +293,14 @@ pub mod pallet {
 			proposal_index: ProposalIndex,
 			proposal_hash: T::Hash,
 			threshold: MemberCount,
+		},
+		/// Proposal vote pending approval
+		VotePendingApproval {
+			dao_id: DaoId,
+			account: T::AccountId,
+			proposal_hash: T::Hash,
+			proposal_index: ProposalIndex,
+			voted: bool,
 		},
 		/// A motion (given hash) has been voted on by given account, leaving
 		/// a tally (yes votes and no votes given respectively as `MemberCount`).
@@ -600,7 +622,33 @@ pub mod pallet {
 			let members = Self::members(dao_id);
 			ensure!(members.contains(&who), Error::<T, I>::NotMember);
 
-			T::DaoProvider::ensure_token_balance(dao_id, &who)?;
+			let pending_vote = PendingVote {
+				who: who.clone(),
+				proposal_hash: proposal,
+				proposal_index: index,
+				vote: approve,
+			};
+
+			let pending_vote_hash = T::Hashing::hash_of(&pending_vote);
+
+			let account_token_balance =
+				T::DaoProvider::ensure_voting_allowed(dao_id, &who, pending_vote_hash)?;
+
+			if let AccountTokenBalance::Offchain { .. } = account_token_balance {
+				// TODO: add checks for vec size limits
+
+				<PendingVoting<T, I>>::insert(dao_id, pending_vote_hash, pending_vote);
+
+				Self::deposit_event(Event::VotePendingApproval {
+					dao_id,
+					account: who,
+					proposal_hash: proposal,
+					proposal_index: index,
+					voted: approve,
+				});
+
+				return Ok(Default::default())
+			}
 
 			// Detects first vote of the member in the motion
 			let is_account_voting_first_time =
@@ -1230,12 +1278,25 @@ impl<T: Config<I>, I: 'static> InitializeDaoMembers<DaoId, T::AccountId> for Pal
 impl<T: Config<I>, I: 'static> ApprovePropose<DaoId, T::AccountId, T::Hash> for Pallet<T, I> {
 	fn approve_propose(dao_id: DaoId, hash: T::Hash, approve: bool) -> Result<(), DispatchError> {
 		let (pending_proposal, proposal) =
-			<PendingProposalOf<T, I>>::take(dao_id, hash).expect("Proposal not found");
+			<PendingProposalOf<T, I>>::take(dao_id, hash).expect("Pending Proposal not found");
 
 		let PendingProposal { who, threshold, length_bound } = pending_proposal;
 
 		if approve {
 			Self::do_propose_proposed(who, dao_id, threshold, Box::new(proposal), length_bound)?;
+		}
+
+		Ok(())
+	}
+}
+
+impl<T: Config<I>, I: 'static> ApproveVote<DaoId, T::AccountId, T::Hash> for Pallet<T, I> {
+	fn approve_vote(dao_id: DaoId, hash: T::Hash, approve: bool) -> Result<(), DispatchError> {
+		let PendingVote { who, proposal_hash, proposal_index, vote } =
+			<PendingVoting<T, I>>::take(dao_id, hash).expect("Pending Vote not found");
+
+		if approve {
+			Self::do_vote(who, dao_id, proposal_hash, proposal_index, vote)?;
 		}
 
 		Ok(())

--- a/pallets/dao-membership/src/lib.rs
+++ b/pallets/dao-membership/src/lib.rs
@@ -102,7 +102,12 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 
 		// TODO: rework providers
-		type DaoProvider: DaoProvider<Id = u32, AccountId = Self::AccountId, Policy = DaoPolicy>;
+		type DaoProvider: DaoProvider<
+			<Self as frame_system::Config>::Hash,
+			Id = u32,
+			AccountId = Self::AccountId,
+			Policy = DaoPolicy,
+		>;
 	}
 
 	/// The current membership, stored as an ordered Vec.

--- a/pallets/dao-primitives/Cargo.toml
+++ b/pallets/dao-primitives/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0.136", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.79", features = ["alloc"], default-features = false }
 
 # Primitives
+sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 sp-std = { version = "4.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 
@@ -33,7 +34,6 @@ frame-system = { version = "4.0.0-dev", default-features = false, git = "https:/
 node-primitives = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 
 [dev-dependencies]
-sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 sp-io = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 

--- a/pallets/dao-primitives/src/lib.rs
+++ b/pallets/dao-primitives/src/lib.rs
@@ -141,6 +141,14 @@ pub struct PendingProposal<AccountId> {
 	pub length_bound: u32,
 }
 
+#[derive(Encode, Decode, Default, Clone, PartialEq, Eq, TypeInfo, RuntimeDebug, MaxEncodedLen)]
+pub struct PendingVote<AccountId, Hash> {
+	pub who: AccountId,
+	pub proposal_hash: Hash,
+	pub proposal_index: u32,
+	pub vote: bool,
+}
+
 #[derive(
 	Encode,
 	Decode,
@@ -192,6 +200,11 @@ pub trait DaoProvider<Hash> {
 		hash: Hash,
 		length_bound: u32,
 	) -> Result<AccountTokenBalance, DispatchError>;
+	fn ensure_voting_allowed(
+		id: Self::Id,
+		who: &Self::AccountId,
+		hash: Hash,
+	) -> Result<AccountTokenBalance, DispatchError>;
 	fn ensure_token_balance(
 		id: Self::Id,
 		who: &Self::AccountId,
@@ -208,6 +221,10 @@ pub trait ContainsDaoMember<DaoId, AccountId> {
 
 pub trait ApprovePropose<DaoId, AccountId, Hash> {
 	fn approve_propose(dao_id: DaoId, hash: Hash, approve: bool) -> Result<(), DispatchError>;
+}
+
+pub trait ApproveVote<DaoId, AccountId, Hash> {
+	fn approve_vote(dao_id: DaoId, hash: Hash, approve: bool) -> Result<(), DispatchError>;
 }
 
 pub trait ApproveTreasuryPropose<DaoId, AccountId, Hash> {

--- a/pallets/dao-primitives/src/lib.rs
+++ b/pallets/dao-primitives/src/lib.rs
@@ -127,6 +127,13 @@ pub struct Dao<AccountId, TokenId, BoundedString, BoundedMetadata> {
 	pub config: DaoConfig<BoundedString, BoundedMetadata>,
 }
 
+#[derive(Encode, Decode, Default, Clone, PartialEq, Eq, TypeInfo, RuntimeDebug, MaxEncodedLen)]
+pub struct PendingDao<AccountId, TokenId, BoundedString, BoundedMetadata, BoundedCouncilMembers> {
+	pub dao: Dao<AccountId, TokenId, BoundedString, BoundedMetadata>,
+	pub policy: DaoPolicy,
+	pub council: BoundedCouncilMembers,
+}
+
 #[derive(
 	Encode,
 	Decode,
@@ -186,6 +193,10 @@ pub trait InitializeDaoMembers<DaoId, AccountId> {
 
 pub trait ContainsDaoMember<DaoId, AccountId> {
 	fn contains(dao_id: DaoId, who: &AccountId) -> Result<bool, DispatchError>;
+}
+
+pub trait MaybeApproveDao<Hash> {
+	fn approve_dao(dao_hash: Hash, approve: bool) -> Result<(), DispatchError>;
 }
 
 pub trait ApprovePropose<DaoId, AccountId, Hash> {

--- a/pallets/dao-treasury/src/lib.rs
+++ b/pallets/dao-treasury/src/lib.rs
@@ -71,11 +71,12 @@ use scale_info::TypeInfo;
 
 use sp_runtime::{
 	traits::{AccountIdConversion, Saturating, StaticLookup, Zero},
-	Permill, RuntimeDebug,
+	DispatchError, Permill, RuntimeDebug,
 };
 use sp_std::prelude::*;
 
 use frame_support::{
+	pallet_prelude::DispatchResult,
 	print,
 	traits::{
 		Currency, EnsureOriginWithArg, ExistenceRequirement::KeepAlive, Get, Imbalance,
@@ -85,10 +86,12 @@ use frame_support::{
 	BoundedVec, PalletId,
 };
 
-use dao_primitives::{DaoPolicy, DaoProvider};
+use dao_primitives::{ApproveTreasuryPropose, DaoPolicy, DaoProvider};
 
 pub use pallet::*;
 pub use weights::WeightInfo;
+
+use sp_runtime::traits::Hash;
 
 pub type BalanceOf<T, I = ()> =
 	<<T as Config<I>>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -148,6 +151,7 @@ pub struct Proposal<AccountId, Balance> {
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
+	use dao_primitives::AccountTokenBalance;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 
@@ -232,6 +236,19 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
+	/// Proposals pending approval.
+	#[pallet::storage]
+	#[pallet::getter(fn pending_proposals)]
+	pub type PendingProposals<T: Config<I>, I: 'static = ()> = StorageDoubleMap<
+		_,
+		Twox64Concat,
+		DaoId,
+		Identity,
+		T::Hash,
+		Proposal<T::AccountId, BalanceOf<T, I>>,
+		OptionQuery,
+	>;
+
 	/// Proposal indices that have been approved but not yet awarded.
 	#[pallet::storage]
 	#[pallet::getter(fn approvals)]
@@ -241,10 +258,21 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config<I>, I: 'static = ()> {
+		// Proposal pending approval
+		ProposalPendingApproval {
+			dao_id: DaoId,
+			proposal_hash: T::Hash,
+		},
 		/// New proposal.
-		Proposed { dao_id: DaoId, proposal_index: ProposalIndex },
+		Proposed {
+			dao_id: DaoId,
+			proposal_index: ProposalIndex,
+		},
 		/// We have ended a spend period and will now allocate funds.
-		Spending { dao_id: DaoId, budget_remaining: BalanceOf<T, I> },
+		Spending {
+			dao_id: DaoId,
+			budget_remaining: BalanceOf<T, I>,
+		},
 		/// Some funds have been allocated.
 		Awarded {
 			dao_id: DaoId,
@@ -253,13 +281,25 @@ pub mod pallet {
 			account: T::AccountId,
 		},
 		/// A proposal was rejected; funds were slashed.
-		Rejected { dao_id: DaoId, proposal_index: ProposalIndex, slashed: BalanceOf<T, I> },
+		Rejected {
+			dao_id: DaoId,
+			proposal_index: ProposalIndex,
+			slashed: BalanceOf<T, I>,
+		},
 		/// Some of our funds have been burnt.
-		Burnt { dao_id: DaoId, burnt_funds: BalanceOf<T, I> },
+		Burnt {
+			dao_id: DaoId,
+			burnt_funds: BalanceOf<T, I>,
+		},
 		/// Spending has finished; this is the amount that rolls over until next spend.
-		Rollover { dao_id: DaoId, rollover_balance: BalanceOf<T, I> },
+		Rollover {
+			dao_id: DaoId,
+			rollover_balance: BalanceOf<T, I>,
+		},
 		/// Some funds have been deposited.
-		Deposit { value: BalanceOf<T, I> },
+		Deposit {
+			value: BalanceOf<T, I>,
+		},
 		/// A new spend proposal has been approved.
 		SpendApproved {
 			dao_id: DaoId,
@@ -334,24 +374,27 @@ pub mod pallet {
 
 			T::DaoProvider::ensure_member(dao_id, &proposer)?;
 
-			T::DaoProvider::ensure_token_balance(dao_id, &proposer)?;
-
 			let beneficiary = T::Lookup::lookup(beneficiary)?;
 
 			let bond = Self::calculate_bond(T::DaoProvider::policy(dao_id)?, value);
-			T::Currency::reserve(&proposer, bond)
-				.map_err(|_| Error::<T, I>::InsufficientProposersBalance)?;
+			let proposal =
+				Proposal { dao_id, proposer: proposer.clone(), value, beneficiary, bond };
+			let proposal_hash = T::Hashing::hash_of(&proposal);
 
-			let c = Self::proposal_count(dao_id);
-			<ProposalCount<T, I>>::insert(dao_id, c + 1);
-			<Proposals<T, I>>::insert(
-				dao_id,
-				c,
-				Proposal { dao_id, proposer, value, beneficiary, bond },
-			);
+			let account_token_balance =
+				T::DaoProvider::ensure_treasury_proposal_allowed(dao_id, &proposer, proposal_hash)?;
 
-			Self::deposit_event(Event::Proposed { dao_id, proposal_index: c });
-			Ok(())
+			if let AccountTokenBalance::Offchain { .. } = account_token_balance {
+				// TODO: add checks for vec size limits
+
+				<PendingProposals<T, I>>::insert(dao_id, proposal_hash, proposal);
+
+				Self::deposit_event(Event::ProposalPendingApproval { dao_id, proposal_hash });
+
+				return Ok(())
+			}
+
+			Self::do_propose_spend(proposal)
 		}
 
 		/// Reject a proposed spend. The original deposit will be slashed.
@@ -523,6 +566,21 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		r
 	}
 
+	pub fn do_propose_spend(proposal: Proposal<T::AccountId, BalanceOf<T, I>>) -> DispatchResult {
+		let Proposal { proposer, dao_id, bond, .. } = proposal.clone();
+
+		T::Currency::reserve(&proposer, bond)
+			.map_err(|_| Error::<T, I>::InsufficientProposersBalance)?;
+
+		let c = Self::proposal_count(dao_id);
+		<ProposalCount<T, I>>::insert(dao_id, c + 1);
+		<Proposals<T, I>>::insert(dao_id, c, proposal);
+
+		Self::deposit_event(Event::Proposed { dao_id, proposal_index: c });
+
+		Ok(())
+	}
+
 	/// Spend some money! returns number of approvals before spend.
 	pub fn spend_funds(dao_id: DaoId) -> Weight {
 		let mut total_weight: Weight = Zero::zero();
@@ -600,6 +658,24 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		T::Currency::free_balance(&T::DaoProvider::dao_account_id(dao_id))
 			// Must never be less than 0 but better be safe.
 			.saturating_sub(T::Currency::minimum_balance())
+	}
+}
+
+impl<T: Config<I>, I: 'static> ApproveTreasuryPropose<DaoId, T::AccountId, T::Hash>
+	for Pallet<T, I>
+{
+	fn approve_treasury_propose(
+		dao_id: DaoId,
+		hash: T::Hash,
+		approve: bool,
+	) -> Result<(), DispatchError> {
+		let proposal = <PendingProposals<T, I>>::take(dao_id, hash).expect("Proposal not found");
+
+		if approve {
+			return Self::do_propose_spend(proposal)
+		}
+
+		Ok(())
 	}
 }
 

--- a/pallets/dao-treasury/src/lib.rs
+++ b/pallets/dao-treasury/src/lib.rs
@@ -205,7 +205,12 @@ pub mod pallet {
 		/// spend at a time.
 		type SpendOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = BalanceOf<Self, I>>;
 
-		type DaoProvider: DaoProvider<Id = u32, AccountId = Self::AccountId, Policy = DaoPolicy>;
+		type DaoProvider: DaoProvider<
+			<Self as frame_system::Config>::Hash,
+			Id = u32,
+			AccountId = Self::AccountId,
+			Policy = DaoPolicy,
+		>;
 	}
 
 	/// Number of proposals that have been made.

--- a/pallets/dao/Cargo.toml
+++ b/pallets/dao/Cargo.toml
@@ -24,6 +24,8 @@ serde = { version = "1.0.136", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.79", features = ["alloc"], default-features = false }
 
 # Primitives
+sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
+sp-io = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 sp-std = { version = "4.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 
@@ -37,7 +39,6 @@ dao-primitives = { version = "4.0.0-dev", default-features = false, path = "../d
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
-sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 sp-io = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }
 

--- a/pallets/dao/Cargo.toml
+++ b/pallets/dao/Cargo.toml
@@ -18,6 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
 	"derive",
 ] }
+hex = { version = "0.4.3", default-features = false }
 log = { version = "0.4.17" }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"], default-features = false }

--- a/pallets/dao/src/lib.rs
+++ b/pallets/dao/src/lib.rs
@@ -1,8 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::HasCompact;
+use codec::{Decode, Encode, HasCompact};
 use frame_support::{
 	dispatch::{DispatchError, DispatchResult},
+	pallet_prelude::*,
 	traits::{
 		tokens::fungibles::{metadata::Mutate as MetadataMutate, Create, Inspect, Mutate},
 		Currency, Get, ReservableCurrency,
@@ -10,10 +11,18 @@ use frame_support::{
 	BoundedVec, PalletId,
 };
 pub use pallet::*;
-use scale_info::TypeInfo;
-use serde::{self};
-use sp_runtime::traits::{AccountIdConversion, AtLeast32BitUnsigned, StaticLookup};
-use sp_std::prelude::*;
+use scale_info::{prelude::*, TypeInfo};
+use serde::{self, Deserialize};
+use sp_core::crypto::KeyTypeId;
+use sp_io::offchain_index;
+use sp_runtime::{
+	offchain,
+	traits::{AccountIdConversion, AtLeast32BitUnsigned, BlockNumberProvider, StaticLookup},
+	transaction_validity::{
+		InvalidTransaction, TransactionSource, TransactionValidity, ValidTransaction,
+	},
+};
+use sp_std::{prelude::*, str};
 
 use dao_primitives::*;
 
@@ -42,11 +51,72 @@ type Balance<T> = <T as Config>::Balance;
 
 pub type BlockNumber = u32;
 
+pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"sctl");
+
+const UNSIGNED_TXS_PRIORITY: u64 = 100;
+
+const HTTP_REMOTE_REQUEST: &str =
+	"https://celo-mainnet.infura.io/v3/9e0a8afb9be04831b75066778842ac8c";
+const ERC20_TOKEN_TOTAL_SUPPLY_SIGNATURE: &str =
+	"0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045";
+
+const FETCH_TIMEOUT_PERIOD: u64 = 3000; // in milli-seconds
+const LOCK_TIMEOUT_EXPIRATION: u64 = FETCH_TIMEOUT_PERIOD + 1000; // in milli-seconds
+const LOCK_BLOCK_EXPIRATION: u32 = 3; // in block number
+
+const ONCHAIN_TX_KEY: &[u8] = b"societal-dao::storage::tx";
+
+pub mod crypto {
+	use crate::KEY_TYPE;
+	use sp_core::sr25519::Signature as Sr25519Signature;
+	use sp_runtime::{
+		app_crypto::{app_crypto, sr25519},
+		traits::Verify,
+		MultiSignature, MultiSigner,
+	};
+
+	app_crypto!(sr25519, KEY_TYPE);
+
+	pub struct TestAuthId;
+	// implemented for societal-node-runtime
+	impl frame_system::offchain::AppCrypto<MultiSigner, MultiSignature> for TestAuthId {
+		type RuntimeAppPublic = Public;
+		type GenericSignature = sp_core::sr25519::Signature;
+		type GenericPublic = sp_core::sr25519::Public;
+	}
+
+	// implemented for mock runtime in test
+	impl frame_system::offchain::AppCrypto<<Sr25519Signature as Verify>::Signer, Sr25519Signature>
+		for TestAuthId
+	{
+		type RuntimeAppPublic = Public;
+		type GenericSignature = sp_core::sr25519::Signature;
+		type GenericPublic = sp_core::sr25519::Public;
+	}
+}
+
+#[derive(Deserialize, Encode, Decode)]
+struct InfuraResponse {
+	#[serde(deserialize_with = "de_string_to_bytes")]
+	result: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize, Encode, Decode, Default)]
+struct IndexingData(Vec<u8>, (u32, Vec<u8>));
+
 #[frame_support::pallet]
 pub mod pallet {
 	pub use super::*;
 	use frame_support::{pallet_prelude::*, traits::fungibles::Transfer};
-	use frame_system::pallet_prelude::*;
+	use frame_system::{
+		offchain::{AppCrypto, CreateSignedTransaction, SubmitTransaction},
+		pallet_prelude::*,
+	};
+	use serde_json::json;
+	use sp_runtime::offchain::{
+		storage::StorageValueRef,
+		storage_lock::{BlockAndTime, StorageLock},
+	};
 
 	/// The current storage version.
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(4);
@@ -57,7 +127,7 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config {
+	pub trait Config: frame_system::Config + CreateSignedTransaction<Call<Self>> {
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type Currency: ReservableCurrency<Self::AccountId>;
 
@@ -128,6 +198,9 @@ pub mod pallet {
 				AssetId = <Self as pallet::Config>::AssetId,
 				Balance = <Self as pallet::Config>::Balance,
 			>;
+
+		/// The identifier type for an offchain worker.
+		type AuthorityId: AppCrypto<Self::Public, Self::Signature>;
 	}
 
 	#[pallet::storage]
@@ -144,12 +217,76 @@ pub mod pallet {
 		StorageMap<_, Blake2_128Concat, u32, PolicyOf, OptionQuery>;
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn offchain_worker(block_number: T::BlockNumber) {
+			log::info!("Entering off-chain worker");
+
+			let key = Self::derived_key(block_number);
+			let storage_ref = StorageValueRef::persistent(&key);
+
+			if let Ok(Some(data)) = storage_ref.get::<IndexingData>() {
+				log::info!(
+					"off-chain indexing data: {:?}, {:?}",
+					str::from_utf8(&data.0).unwrap_or("error"),
+					data.1
+				);
+
+				let dao_id = data.1 .0;
+				let token_address = data.1 .1;
+
+				let result = Self::fetch_token_total_supply(token_address);
+				if let Err(e) = result {
+					log::error!("offchain_worker error: {:?}", e);
+
+					//TODO: disapprove dao - remove?
+
+					return
+				}
+
+				let call = Call::approve_dao { dao_id };
+
+				let result =
+					SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into())
+						.map_err(|_| {
+							log::error!("Failed in offchain_unsigned_tx");
+							<Error<T>>::OffchainUnsignedTxError
+						});
+
+				if let Err(_) = result {
+					log::error!("dao approval error: {:?}", dao_id);
+				}
+			} else {
+				log::info!("no off-chain indexing data retrieved.");
+			}
+		}
+	}
+
+	#[pallet::validate_unsigned]
+	impl<T: Config> frame_support::unsigned::ValidateUnsigned for Pallet<T> {
+		type Call = Call<T>;
+
+		fn validate_unsigned(_source: TransactionSource, call: &Self::Call) -> TransactionValidity {
+			let valid_tx = |provide| {
+				ValidTransaction::with_tag_prefix("societal-node")
+					.priority(UNSIGNED_TXS_PRIORITY)
+					.and_provides([&provide])
+					.longevity(3)
+					.propagate(true)
+					.build()
+			};
+
+			match call {
+				Call::approve_dao { dao_id } => valid_tx(b"approve_dao".to_vec()),
+				_ => InvalidTransaction::Call.into(),
+			}
+		}
+	}
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		DaoRegistered(u32, T::AccountId),
+		DaoApproved(u32),
 	}
 
 	#[pallet::error]
@@ -166,8 +303,12 @@ pub mod pallet {
 		TokenBalanceInvalid,
 		TokenBalanceLow,
 		TokenTransferFailed,
+		TokenAddressInvalid,
 		InvalidInput,
 		PolicyNotExist,
+		// Error returned when fetching http
+		HttpFetchingError,
+		OffchainUnsignedTxError,
 	}
 
 	#[pallet::call]
@@ -211,6 +352,8 @@ pub mod pallet {
 			}
 
 			let mut has_token_id: Option<AssetId<T>> = None;
+			let mut has_token_address: Option<BoundedVec<u8, <T as Config>::DaoStringLimit>> = None;
+			let mut dao_status: DaoStatus = DaoStatus::Pending;
 
 			if let Some(token) = dao.token {
 				let token_id = Self::u32_to_asset_id(token.token_id);
@@ -262,6 +405,8 @@ pub mod pallet {
 						.map_err(|_| Error::<T>::TokenTransferFailed)?;
 					}
 				}
+
+				dao_status = DaoStatus::Success;
 			}
 
 			if has_token_id.is_none() {
@@ -275,10 +420,23 @@ pub mod pallet {
 					if issuance == 0 {
 						return Err(Error::<T>::TokenNotExists.into())
 					}
+
+					dao_status = DaoStatus::Success;
+				} else if let Some(token_address) = dao.token_address {
+					let token_address =
+						BoundedVec::<u8, T::DaoStringLimit>::try_from(token_address)
+							.map_err(|_| Error::<T>::TokenAddressInvalid)?;
+					has_token_address = Some(token_address.clone());
+
+					let key = Self::derived_key(frame_system::Pallet::<T>::block_number());
+					let data: IndexingData =
+						IndexingData(b"approve_dao".to_vec(), (dao_id, Vec::from(token_address)));
+
+					offchain_index::set(&key, &data.encode());
 				}
 			}
 
-			if has_token_id.is_none() {
+			if has_token_id.is_none() && has_token_address.is_none() {
 				return Err(Error::<T>::TokenNotProvided.into())
 			}
 
@@ -298,7 +456,9 @@ pub mod pallet {
 			let dao = Dao {
 				founder: who.clone(),
 				account_id: dao_account_id,
-				token_id: has_token_id.unwrap(),
+				token_id: has_token_id,
+				token_address: has_token_address,
+				status: dao_status,
 				config: DaoConfig { name: dao_name, purpose: dao_purpose, metadata: dao_metadata },
 			};
 			Daos::<T>::insert(dao_id, dao);
@@ -308,6 +468,26 @@ pub mod pallet {
 			<NextDaoId<T>>::put(dao_id.checked_add(1).unwrap());
 
 			Self::deposit_event(Event::DaoRegistered(dao_id, who));
+
+			Ok(())
+		}
+
+		#[pallet::weight(10_000)]
+		pub fn approve_dao(origin: OriginFor<T>, dao_id: u32) -> DispatchResult {
+			ensure_none(origin)?;
+
+			let dao_option = Daos::<T>::get(dao_id);
+
+			if dao_option.is_none() {
+				return Err(Error::<T>::DaoNotExist.into())
+			}
+
+			let mut dao = dao_option.unwrap();
+			dao.status = DaoStatus::Success;
+
+			Daos::<T>::insert(dao_id, dao);
+
+			Self::deposit_event(Event::DaoApproved(dao_id));
 
 			Ok(())
 		}
@@ -328,6 +508,100 @@ pub mod pallet {
 
 		fn u128_to_balance_of(cost: u128) -> BalanceOf<T> {
 			TryInto::<BalanceOf<T>>::try_into(cost).ok().unwrap()
+		}
+
+		#[deny(clippy::clone_double_ref)]
+		fn derived_key(block_number: T::BlockNumber) -> Vec<u8> {
+			block_number.using_encoded(|encoded_bn| {
+				ONCHAIN_TX_KEY
+					.iter()
+					.chain(b"/".iter())
+					.chain(encoded_bn)
+					.copied()
+					.collect::<Vec<u8>>()
+			})
+		}
+
+		fn fetch_token_total_supply(token_address: Vec<u8>) -> Result<(), Error<T>> {
+			let s_info = StorageValueRef::persistent(b"societal-node::eth-token-total-supply");
+
+			if let Ok(Some(_infura_response)) = s_info.get::<InfuraResponse>() {
+				return Ok(())
+			}
+
+			let mut lock = StorageLock::<BlockAndTime<Self>>::with_block_and_time_deadline(
+				b"societal-dao::lock",
+				LOCK_BLOCK_EXPIRATION,
+				offchain::Duration::from_millis(LOCK_TIMEOUT_EXPIRATION),
+			);
+
+			if let Ok(_guard) = lock.try_lock() {
+				let to = str::from_utf8(&token_address[..]).expect("Failed to serialize");
+				let json = json!({
+					"jsonrpc": "2.0",
+					"method": "eth_call",
+					"id": 1,
+					"params": [
+						{
+							"to": to,
+							"data": ERC20_TOKEN_TOTAL_SUPPLY_SIGNATURE
+						},
+						"latest"
+					]
+				});
+				let body = &serde_json::to_vec(&json).expect("Failed to serialize")[..];
+
+				match Self::fetch_n_parse(vec![body]) {
+					Ok(infura_response) => {
+						s_info.set(&infura_response);
+					},
+					Err(err) => return Err(err),
+				}
+			}
+			Ok(())
+		}
+
+		fn fetch_n_parse(body: Vec<&[u8]>) -> Result<InfuraResponse, Error<T>> {
+			let resp_bytes = Self::fetch_from_remote(body).map_err(|e| {
+				log::error!("fetch_from_remote error: {:?}", e);
+				<Error<T>>::HttpFetchingError
+			})?;
+
+			let resp_str =
+				str::from_utf8(&resp_bytes).map_err(|_| <Error<T>>::HttpFetchingError)?;
+
+			let infura_response: InfuraResponse =
+				serde_json::from_str(resp_str).map_err(|_| <Error<T>>::HttpFetchingError)?;
+
+			log::info!("info: {:?}", infura_response.result);
+
+			Ok(infura_response)
+		}
+
+		fn fetch_from_remote(body: Vec<&[u8]>) -> Result<Vec<u8>, Error<T>> {
+			let request = offchain::http::Request::post(HTTP_REMOTE_REQUEST, body);
+
+			// Keeping the offchain worker execution time reasonable, so limiting the call to be
+			// within 3s.
+			let timeout = sp_io::offchain::timestamp()
+				.add(offchain::Duration::from_millis(FETCH_TIMEOUT_PERIOD));
+
+			let pending = request
+				.deadline(timeout) // Setting the timeout time
+				.send() // Sending the request out by the host
+				.map_err(|_| <Error<T>>::HttpFetchingError)?;
+
+			let response = pending
+				.try_wait(timeout)
+				.map_err(|_| <Error<T>>::HttpFetchingError)?
+				.map_err(|_| <Error<T>>::HttpFetchingError)?;
+
+			if response.code != 200 {
+				log::error!("Unexpected http request status code: {}", response.code);
+				return Err(<Error<T>>::HttpFetchingError)
+			}
+
+			Ok(response.body().collect::<Vec<u8>>())
 		}
 	}
 }
@@ -362,12 +636,19 @@ impl<T: Config> DaoProvider for Pallet<T> {
 	}
 
 	fn ensure_token_balance(id: Self::Id, who: &Self::AccountId) -> Result<(), DispatchError> {
-		let dao = Daos::<T>::get(id).ok_or_else(|| Error::<T>::DaoNotExist)?;
+		let dao = Daos::<T>::get(id).ok_or(Error::<T>::DaoNotExist)?;
 
-		if T::AssetProvider::balance(dao.token_id, who) <
-			Self::u128_to_balance(T::DaoTokenVotingMinThreshold::get())
-		{
-			return Err(Error::<T>::TokenBalanceLow.into())
+		// TODO: rework
+		if dao.token_id.is_some() {
+			if T::AssetProvider::balance(dao.token_id.unwrap(), who) <
+				Self::u128_to_balance(T::DaoTokenVotingMinThreshold::get())
+			{
+				return Err(Error::<T>::TokenBalanceLow.into())
+			}
+		} else if dao.token_address.is_some() {
+			// TODO
+
+			return Ok(())
 		}
 
 		Ok(())
@@ -375,5 +656,12 @@ impl<T: Config> DaoProvider for Pallet<T> {
 
 	fn dao_account_id(id: Self::Id) -> Self::AccountId {
 		Self::account_id(id)
+	}
+}
+
+impl<T: Config> BlockNumberProvider for Pallet<T> {
+	type BlockNumber = T::BlockNumber;
+	fn current_block_number() -> Self::BlockNumber {
+		<frame_system::Pallet<T>>::block_number()
 	}
 }

--- a/pallets/dao/src/lib.rs
+++ b/pallets/dao/src/lib.rs
@@ -597,6 +597,7 @@ pub mod pallet {
 					}
 				}
 
+				dao.token_id = has_token_id;
 				dao.status = DaoStatus::Success;
 			}
 
@@ -612,6 +613,7 @@ pub mod pallet {
 						return Err(Error::<T>::TokenNotExists.into())
 					}
 
+					dao.token_id = has_token_id;
 					dao.status = DaoStatus::Success;
 				} else if let Some(token_address) = dao_payload.token_address {
 					let address =

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 # third-party dependencies
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+log = { version = "0.4.17" }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 static_assertions = "1.1.0"
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1470,6 +1470,7 @@ parameter_types! {
 	pub const DaoPalletId: PalletId = PalletId(*b"py/sctld");
 	pub const DaoStringLimit: u32 = 50;
 	pub const DaoMetadataLimit: u32 = 500;
+	pub const DaoMaxCouncilMembers: u32 = 100; // TODO
 	pub const DaoTokenMinBalanceLimit: u128 = 1_000;
 	pub const DaoTokenBalanceLimit: u128 = 1_000_000_000;
 	pub const DaoTokenVotingMinThreshold: u128 = 1_000;
@@ -1481,6 +1482,7 @@ impl pallet_dao::Config for Runtime {
 	type PalletId = DaoPalletId;
 	type DaoStringLimit = DaoStringLimit;
 	type DaoMetadataLimit = DaoMetadataLimit;
+	type DaoMaxCouncilMembers = DaoMaxCouncilMembers;
 	type DaoTokenMinBalanceLimit = DaoTokenMinBalanceLimit;
 	type DaoTokenBalanceLimit = DaoTokenBalanceLimit;
 	type DaoTokenVotingMinThreshold = DaoTokenVotingMinThreshold;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -44,7 +44,7 @@ use sp_runtime::{
 	generic, impl_opaque_keys,
 	traits::{
 		AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto, Dispatchable, NumberFor,
-		OpaqueKeys,
+		OpaqueKeys, SaturatedConversion,
 	},
 	transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, ConsensusEngineId, FixedU128, Percent,
@@ -1489,6 +1489,55 @@ impl pallet_dao::Config for Runtime {
 	type ExpectedBlockTime = ExpectedBlockTime;
 	type CouncilProvider = DaoCouncilMemberships;
 	type AssetProvider = Assets;
+	type AuthorityId = pallet_dao::crypto::TestAuthId;
+}
+
+impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Runtime
+where
+	RuntimeCall: From<LocalCall>,
+{
+	fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
+		call: RuntimeCall,
+		public: <Signature as sp_runtime::traits::Verify>::Signer,
+		account: AccountId,
+		index: Index,
+	) -> Option<(
+		RuntimeCall,
+		<UncheckedExtrinsic as sp_runtime::traits::Extrinsic>::SignaturePayload,
+	)> {
+		let period = BlockHashCount::get() as u64;
+		let current_block = System::block_number().saturated_into::<u64>().saturating_sub(1);
+		let tip = 0;
+
+		let extra: SignedExtra = (
+			frame_system::CheckNonZeroSender::<Runtime>::new(),
+			frame_system::CheckSpecVersion::<Runtime>::new(),
+			frame_system::CheckTxVersion::<Runtime>::new(),
+			frame_system::CheckGenesis::<Runtime>::new(),
+			frame_system::CheckEra::<Runtime>::from(generic::Era::mortal(period, current_block)),
+			frame_system::CheckNonce::<Runtime>::from(index),
+			frame_system::CheckWeight::<Runtime>::new(),
+			pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
+		);
+
+		#[cfg_attr(not(feature = "std"), allow(unused_variables))]
+		let raw_payload = SignedPayload::new(call, extra)
+			.map_err(|e| {
+				log::info!("SignedPayload error: {:?}", e);
+			})
+			.ok()?;
+
+		let signature = raw_payload.using_encoded(|payload| C::sign(payload, public))?;
+
+		let address = account;
+		let (call, extra, _) = raw_payload.deconstruct();
+		Some((call, (Address::from(address), signature, extra)))
+	}
+}
+
+impl frame_system::offchain::SigningTypes for Runtime {
+	type Public = <Signature as sp_runtime::traits::Verify>::Signer;
+	type Signature = Signature;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1488,6 +1488,7 @@ impl pallet_dao::Config for Runtime {
 	type Balance = Balance;
 	type ExpectedBlockTime = ExpectedBlockTime;
 	type CouncilProvider = DaoCouncilMemberships;
+	type CouncilApproveProvider = DaoCouncil;
 	type AssetProvider = Assets;
 	type AuthorityId = pallet_dao::crypto::TestAuthId;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1491,6 +1491,7 @@ impl pallet_dao::Config for Runtime {
 	type ExpectedBlockTime = ExpectedBlockTime;
 	type CouncilProvider = DaoCouncilMemberships;
 	type CouncilApproveProvider = DaoCouncil;
+	type ApproveTreasuryPropose = DaoTreasury;
 	type AssetProvider = Assets;
 	type AuthorityId = pallet_dao::crypto::TestAuthId;
 }


### PR DESCRIPTION
Added support for eth token address for DAO:

- Specify 'token_address' to add support for eth tokens as a DAO voting token
- added offchain worker support
- checking token supply on dao creation - deny if not exists or total supply equals to 0
- checking proposer token balance on proposal creation - deny if less than amount pre-defined
- checking proposal voter balance while voting on proposal - deny if less than amount pre-defined