### PR TITLE
DAO Collective pallet changes 

### DIFF
--- a/pallets/dao-collective/src/benchmarking.rs
+++ b/pallets/dao-collective/src/benchmarking.rs
@@ -61,8 +61,6 @@ benchmarks_instance_pallet! {
 			T::MaxMembers::get(),
 		)?;
 
-		// Set a high threshold for proposals passing so that they stay around.
-		let threshold = m.max(2);
 		// Length of the proposals should be irrelevant to `set_members`.
 		let length = 100;
 		for i in 0 .. p {
@@ -73,7 +71,6 @@ benchmarks_instance_pallet! {
 			Collective::<T, I>::propose(
 				SystemOrigin::Signed(last_old_member.clone()).into(),
 				0,
-				threshold,
 				Box::new(proposal.clone()),
 				MAX_BYTES,
 			)?;
@@ -158,9 +155,8 @@ benchmarks_instance_pallet! {
 		Collective::<T, I>::set_members(SystemOrigin::Root.into(), 0, members, T::MaxMembers::get())?;
 
 		let proposal: T::Proposal = SystemCall::<T>::remark {  remark: vec![1; b as usize] }.into();
-		let threshold = 1;
 
-	}: propose(SystemOrigin::Signed(caller), 0, threshold, Box::new(proposal.clone()), bytes_in_storage)
+	}: propose(SystemOrigin::Signed(caller), 0, Box::new(proposal.clone()), bytes_in_storage)
 	verify {
 		let proposal_hash = T::Hashing::hash_of(&proposal);
 		// Note that execution fails due to mis-matched origin
@@ -187,7 +183,6 @@ benchmarks_instance_pallet! {
 		members.push(caller.clone());
 		Collective::<T, I>::set_members(SystemOrigin::Root.into(), 0, members, T::MaxMembers::get())?;
 
-		let threshold = m;
 		// Add previous proposals.
 		for i in 0 .. p - 1 {
 			// Proposals should be different so that different proposal hashes are generated
@@ -195,7 +190,6 @@ benchmarks_instance_pallet! {
 			Collective::<T, I>::propose(
 				SystemOrigin::Signed(caller.clone()).into(),
 				0,
-				threshold,
 				Box::new(proposal),
 				bytes_in_storage,
 			)?;
@@ -205,12 +199,12 @@ benchmarks_instance_pallet! {
 
 		let proposal: T::Proposal = SystemCall::<T>::remark { remark: vec![p as u8; b as usize] }.into();
 
-	}: propose(SystemOrigin::Signed(caller.clone()), 0, threshold, Box::new(proposal.clone()), bytes_in_storage)
+	}: propose(SystemOrigin::Signed(caller.clone()), 0, Box::new(proposal.clone()), bytes_in_storage)
 	verify {
 		// New proposal is recorded
 		assert_eq!(Collective::<T, I>::proposals(0).len(), p as usize);
 		let proposal_hash = T::Hashing::hash_of(&proposal);
-		assert_last_event::<T, I>(Event::Proposed { dao_id: 0, account: caller, proposal_index: p - 1, proposal_hash, threshold }.into());
+		assert_last_event::<T, I>(Event::Proposed { dao_id: 0, account: caller, proposal_index: p - 1, proposal_hash, threshold: m }.into());
 	}
 
 	vote {
@@ -233,9 +227,6 @@ benchmarks_instance_pallet! {
 		members.push(voter.clone());
 		Collective::<T, I>::set_members(SystemOrigin::Root.into(), 0, members.clone(), T::MaxMembers::get())?;
 
-		// Threshold is 1 less than the number of members so that one person can vote nay
-		let threshold = m - 1;
-
 		// Add previous proposals
 		let mut last_hash = T::Hash::default();
 		for i in 0 .. p {
@@ -244,7 +235,6 @@ benchmarks_instance_pallet! {
 			Collective::<T, I>::propose(
 				SystemOrigin::Signed(proposer.clone()).into(),
 				0,
-				threshold,
 				Box::new(proposal.clone()),
 				bytes_in_storage,
 			)?;
@@ -311,9 +301,6 @@ benchmarks_instance_pallet! {
 		members.push(voter.clone());
 		Collective::<T, I>::set_members(SystemOrigin::Root.into(), 0, members.clone(), T::MaxMembers::get())?;
 
-		// Threshold is total members so that one nay will disapprove the vote
-		let threshold = m;
-
 		// Add previous proposals
 		let mut last_hash = T::Hash::default();
 		for i in 0 .. p {
@@ -325,7 +312,6 @@ benchmarks_instance_pallet! {
 			Collective::<T, I>::propose(
 				SystemOrigin::Signed(proposer.clone()).into(),
 				0,
-				threshold,
 				Box::new(proposal.clone()),
 				bytes_in_storage,
 			)?;
@@ -395,9 +381,6 @@ benchmarks_instance_pallet! {
 		members.push(caller.clone());
 		Collective::<T, I>::set_members(SystemOrigin::Root.into(), 0, members.clone(), T::MaxMembers::get())?;
 
-		// Threshold is 2 so any two ayes will approve the vote
-		let threshold = 2;
-
 		// Add previous proposals
 		let mut last_hash = T::Hash::default();
 		for i in 0 .. p {
@@ -406,7 +389,6 @@ benchmarks_instance_pallet! {
 			Collective::<T, I>::propose(
 				SystemOrigin::Signed(caller.clone()).into(),
 				0,
-				threshold,
 				Box::new(proposal.clone()),
 				bytes_in_storage,
 			)?;
@@ -487,9 +469,6 @@ benchmarks_instance_pallet! {
 			T::MaxMembers::get(),
 		)?;
 
-		// Threshold is one less than total members so that two nays will disapprove the vote
-		let threshold = m - 1;
-
 		// Add proposals
 		let mut last_hash = T::Hash::default();
 		for i in 0 .. p {
@@ -501,7 +480,6 @@ benchmarks_instance_pallet! {
 			Collective::<T, I>::propose(
 				SystemOrigin::Signed(caller.clone()).into(),
 				0,
-				threshold,
 				Box::new(proposal.clone()),
 				bytes_in_storage,
 			)?;
@@ -562,9 +540,6 @@ benchmarks_instance_pallet! {
 			T::MaxMembers::get(),
 		)?;
 
-		// Threshold is two, so any two ayes will pass the vote
-		let threshold = 2;
-
 		// Add proposals
 		let mut last_hash = T::Hash::default();
 		for i in 0 .. p {
@@ -573,7 +548,6 @@ benchmarks_instance_pallet! {
 			Collective::<T, I>::propose(
 				SystemOrigin::Signed(caller.clone()).into(),
 				0,
-				threshold,
 				Box::new(proposal.clone()),
 				bytes_in_storage,
 			)?;
@@ -633,9 +607,6 @@ benchmarks_instance_pallet! {
 			T::MaxMembers::get(),
 		)?;
 
-		// Threshold is one less than total members so that two nays will disapprove the vote
-		let threshold = m - 1;
-
 		// Add proposals
 		let mut last_hash = T::Hash::default();
 		for i in 0 .. p {
@@ -644,7 +615,6 @@ benchmarks_instance_pallet! {
 			Collective::<T, I>::propose(
 				SystemOrigin::Signed(caller.clone()).into(),
 				0,
-				threshold,
 				Box::new(proposal.clone()),
 				bytes_in_storage,
 			)?;

--- a/pallets/dao-primitives/src/lib.rs
+++ b/pallets/dao-primitives/src/lib.rs
@@ -9,6 +9,7 @@ pub use node_primitives::Balance;
 
 use scale_info::TypeInfo;
 use serde::{self, Deserialize, Deserializer, Serialize};
+use sp_core::{crypto::AccountId32, H256};
 use sp_runtime::RuntimeDebug;
 use sp_std::prelude::*;
 
@@ -323,8 +324,20 @@ pub trait ApprovePropose<DaoId, AccountId, Hash> {
 	fn approve_propose(dao_id: DaoId, hash: Hash, approve: bool) -> Result<(), DispatchError>;
 }
 
+impl ApprovePropose<u32, AccountId32, H256> for () {
+	fn approve_propose(dao_id: u32, hash: H256, approve: bool) -> Result<(), DispatchError> {
+		Ok(())
+	}
+}
+
 pub trait ApproveVote<DaoId, AccountId, Hash> {
 	fn approve_vote(dao_id: DaoId, hash: Hash, approve: bool) -> Result<(), DispatchError>;
+}
+
+impl ApproveVote<u32, AccountId32, H256> for () {
+	fn approve_vote(dao_id: u32, hash: H256, approve: bool) -> Result<(), DispatchError> {
+		Ok(())
+	}
 }
 
 pub trait ApproveTreasuryPropose<DaoId, AccountId, Hash> {

--- a/pallets/dao/src/lib.rs
+++ b/pallets/dao/src/lib.rs
@@ -239,9 +239,6 @@ pub mod pallet {
 		type TechnicalCommitteeProvider: InitializeDaoMembers<u32, Self::AccountId>
 			+ ContainsDaoMember<u32, Self::AccountId>;
 
-		type TechnicalCommitteeApproveProvider: ApprovePropose<u32, Self::AccountId, Self::Hash>
-			+ ApproveVote<u32, Self::AccountId, Self::Hash>;
-
 		type ApproveTreasuryPropose: ApproveTreasuryPropose<u32, Self::AccountId, Self::Hash>;
 
 		type AssetProvider: Inspect<

--- a/precompiles/dao-collective/src/lib.rs
+++ b/precompiles/dao-collective/src/lib.rs
@@ -171,7 +171,6 @@ where
 				Some(origin).into(),
 				pallet_dao_collective::Call::<Runtime, Instance>::propose {
 					dao_id,
-					threshold,
 					proposal,
 					length_bound: proposal_length,
 				},

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1587,9 +1587,8 @@ impl pallet_dao::Config for Runtime {
 	type Balance = Balance;
 	type ExpectedBlockTime = ExpectedBlockTime;
 	type CouncilProvider = DaoCouncilMembers;
-	type CouncilApproveProvider = DaoCouncil;
+	type CouncilApproveProvider = ();
 	type TechnicalCommitteeProvider = DaoTechnicalCommitteeMembers;
-	type TechnicalCommitteeApproveProvider = DaoTechnicalCommittee;
 	type ApproveTreasuryPropose = DaoTreasury;
 	type AssetProvider = Assets;
 	type AuthorityId = pallet_dao::crypto::TestAuthId;

--- a/runtime/src/precompiles.rs
+++ b/runtime/src/precompiles.rs
@@ -36,7 +36,10 @@ pub type FrontierPrecompiles<R> = PrecompileSetBuilder<
 				PrecompileAt<AddressU64<2048>, DaoPrecompile<R>>,
 				PrecompileAt<AddressU64<2049>, DaoTreasuryPrecompile<R>>,
 				PrecompileAt<AddressU64<2050>, DaoCollectivePrecompile<R, DaoCouncilCollective>>,
-				PrecompileAt<AddressU64<2051>, DaoCollectivePrecompile<R, DaoTechnicalCommitteeCollective>>,
+				PrecompileAt<
+					AddressU64<2051>,
+					DaoCollectivePrecompile<R, DaoTechnicalCommitteeCollective>,
+				>,
 				PrecompileAt<AddressU64<2052>, DaoMembershipPrecompile<R, DaoCouncilMembership>>,
 				PrecompileAt<AddressU64<2053>, DaoDemocracyPrecompile<R>>,
 			),


### PR DESCRIPTION
- removed pending proposal/vote entities that will be moved to a separate dao eth governance pallet
- removed 'threshold' argument for dao collective pallet proposals, a threshold is calculated based on the dao approve origin policy.