### PR TITLE
*making dao token 'sufficient'

### DIFF
--- a/pallets/dao/src/lib.rs
+++ b/pallets/dao/src/lib.rs
@@ -627,7 +627,7 @@ pub mod pallet {
 					T::AssetProvider::create(
 						token_id,
 						dao_account_id.clone(),
-						false,
+						true,
 						token_min_balance,
 					)
 					.map_err(|_| Error::<T>::TokenCreateFailed)?;
@@ -757,7 +757,7 @@ pub mod pallet {
 					});
 				},
 				DaoToken::EthTokenAddress(_) => {
-					// TODO: handle token_address
+					return Err(Error::<T>::DaoNotExist.into());
 				},
 			}
 


### PR DESCRIPTION
Using 'sufficient' flag while creating dao fungible token. It is required to enable token transfers to the eth accounts with 0 native token balance.