### PR TITLE
EVM-to-Substrate Assets Mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -1214,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90d59d9acd2a682b4e40605a242f6670eaa58c5957471cbf85e8aa6a0b97a5e8"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1226,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfa40bda659dd5c864e65f4c9a2b0aff19bea56b017b9b77c73d3766a453a38"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1241,15 +1241,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457ce6757c5c70dc6ecdbda6925b958aae7f959bda7d8fb9bde889e34a09dc03"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf883b7aacd7b2aeb2a7b338648ee19f57c140d4ee8e52c68979c6b2f7f2263"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1752,6 +1752,12 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "faster-hex"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e2ce894d53b295cf97b05685aa077950ff3e8541af83217fc720a6437169f8"
 
 [[package]]
 name = "fastrand"
@@ -4817,6 +4823,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-dao-assets"
+version = "4.0.0-dev"
+source = "git+https://github.com/sctllabs/societal-node?branch=main#30071aefbe937d8c0f700092ad71074a0ac3058a"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-dao-bounties"
 version = "4.0.0-dev"
 dependencies = [
@@ -4826,7 +4848,7 @@ dependencies = [
  "frame-system",
  "log",
  "pallet-balances",
- "pallet-dao-assets",
+ "pallet-dao-assets 4.0.0-dev (git+https://github.com/sctllabs/societal-node?branch=main)",
  "pallet-dao-treasury",
  "parity-scale-codec",
  "scale-info",
@@ -4864,7 +4886,7 @@ dependencies = [
  "pallet-dao-collective",
  "pallet-evm",
  "parity-scale-codec",
- "precompile-utils",
+ "precompile-utils 0.1.0 (git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32)",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -4880,7 +4902,7 @@ dependencies = [
  "frame-system",
  "log",
  "pallet-balances",
- "pallet-dao-assets",
+ "pallet-dao-assets 4.0.0-dev (git+https://github.com/sctllabs/societal-node?branch=main)",
  "pallet-preimage",
  "pallet-scheduler",
  "parity-scale-codec",
@@ -4910,7 +4932,7 @@ dependencies = [
  "pallet-scheduler",
  "pallet-timestamp",
  "parity-scale-codec",
- "precompile-utils",
+ "precompile-utils 0.1.0 (git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32)",
  "scale-info",
  "serde",
  "sp-core",
@@ -4952,7 +4974,7 @@ dependencies = [
  "pallet-dao-eth-governance",
  "pallet-evm",
  "parity-scale-codec",
- "precompile-utils",
+ "precompile-utils 0.1.0 (git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32)",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -4986,7 +5008,7 @@ dependencies = [
  "pallet-dao-membership",
  "pallet-evm",
  "parity-scale-codec",
- "precompile-utils",
+ "precompile-utils 0.1.0 (git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32)",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -5003,7 +5025,7 @@ dependencies = [
  "pallet-dao",
  "pallet-evm",
  "parity-scale-codec",
- "precompile-utils",
+ "precompile-utils 0.1.0 (git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32)",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -5040,7 +5062,7 @@ dependencies = [
  "pallet-dao-treasury",
  "pallet-evm",
  "parity-scale-codec",
- "precompile-utils",
+ "precompile-utils 0.1.0 (git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32)",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -5256,6 +5278,31 @@ dependencies = [
  "fp-evm",
  "ripemd",
  "sp-io",
+]
+
+[[package]]
+name = "pallet-evm-precompileset-assets-erc20"
+version = "0.1.0"
+source = "git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32-asset-manager#da5001aeccb3bf9f2d3b890a550dcc70824adc29"
+dependencies = [
+ "fp-evm",
+ "frame-support",
+ "frame-system",
+ "log",
+ "num_enum",
+ "pallet-balances",
+ "pallet-dao-assets 4.0.0-dev (git+https://github.com/sctllabs/societal-node?branch=main)",
+ "pallet-evm",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "paste",
+ "precompile-utils 0.1.0 (git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32-asset-manager)",
+ "scale-info",
+ "slices",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -6114,7 +6161,32 @@ dependencies = [
  "pallet-evm",
  "parity-scale-codec",
  "paste",
- "precompile-utils-macro",
+ "precompile-utils-macro 0.1.0 (git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32)",
+ "sha3 0.9.1",
+ "sp-core",
+ "sp-io",
+ "sp-std",
+ "xcm",
+]
+
+[[package]]
+name = "precompile-utils"
+version = "0.1.0"
+source = "git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32-asset-manager#da5001aeccb3bf9f2d3b890a550dcc70824adc29"
+dependencies = [
+ "affix",
+ "evm",
+ "fp-evm",
+ "frame-support",
+ "frame-system",
+ "hex",
+ "impl-trait-for-tuples",
+ "log",
+ "num_enum",
+ "pallet-evm",
+ "parity-scale-codec",
+ "paste",
+ "precompile-utils-macro 0.1.0 (git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32-asset-manager)",
  "sha3 0.9.1",
  "sp-core",
  "sp-io",
@@ -6126,6 +6198,20 @@ dependencies = [
 name = "precompile-utils-macro"
 version = "0.1.0"
 source = "git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32#4bb2b50d305584046678cb402446d622abfc6d3f"
+dependencies = [
+ "case",
+ "num_enum",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "sha3 0.8.2",
+ "syn",
+]
+
+[[package]]
+name = "precompile-utils-macro"
+version = "0.1.0"
+source = "git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32-asset-manager#da5001aeccb3bf9f2d3b890a550dcc70824adc29"
 dependencies = [
  "case",
  "num_enum",
@@ -8319,6 +8405,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 
 [[package]]
+name = "slices"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2086e458a369cdca838e9f6ed04b4cc2e3ce636d99abb80c9e2eada107749cf"
+dependencies = [
+ "faster-hex",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8468,7 +8566,7 @@ dependencies = [
  "pallet-contracts-primitives",
  "pallet-conviction-voting",
  "pallet-dao",
- "pallet-dao-assets",
+ "pallet-dao-assets 4.0.0-dev (git+https://github.com/sctllabs/societal-node?branch=main)",
  "pallet-dao-bounties",
  "pallet-dao-collective",
  "pallet-dao-collective-precompile",
@@ -8494,6 +8592,7 @@ dependencies = [
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",
+ "pallet-evm-precompileset-assets-erc20",
  "pallet-grandpa",
  "pallet-hotfix-sufficients",
  "pallet-im-online",
@@ -8522,7 +8621,7 @@ dependencies = [
  "pallet-utility",
  "pallet-vesting",
  "parity-scale-codec",
- "precompile-utils",
+ "precompile-utils 0.1.0 (git+https://github.com/sctllabs/moonbeam.git?branch=moonbeam-polkadot-v0.9.32)",
  "scale-info",
  "sp-api",
  "sp-authority-discovery",

--- a/pallets/dao-assets/src/mock.rs
+++ b/pallets/dao-assets/src/mock.rs
@@ -87,7 +87,7 @@ impl pallet_balances::Config for Test {
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = u64;
-	type AssetId = u32;
+	type AssetId = u128;
 	type Currency = Balances;
 	type ForceOrigin = frame_system::EnsureRoot<u64>;
 	type AssetDeposit = ConstU64<1>;

--- a/pallets/dao-bounties/Cargo.toml
+++ b/pallets/dao-bounties/Cargo.toml
@@ -34,7 +34,7 @@ frame-system = { version = "4.0.0-dev", default-features = false, git = "https:/
 
 # Local Dependencies
 dao-primitives = { version = "4.0.0-dev", default-features = false, path = "../../primitives/dao" }
-pallet-dao-assets = { version = "4.0.0-dev", default-features = false, path = "../dao-assets" }
+pallet-dao-assets = { version = "4.0.0-dev", default-features = false, git = "https://github.com/sctllabs/societal-node", branch = "main" }
 pallet-dao-treasury = { version = "4.0.0-dev", default-features = false, path = "../dao-treasury" }
 
 [dev-dependencies]

--- a/pallets/dao-bounties/src/tests.rs
+++ b/pallets/dao-bounties/src/tests.rs
@@ -112,7 +112,7 @@ impl pallet_dao_assets::Config for Test {
 	type Balance = Balance;
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
-	type AssetId = u32;
+	type AssetId = u128;
 	type Currency = pallet_balances::Pallet<Test>;
 	type ForceOrigin = EnsureRoot<AccountId>;
 	type AssetDeposit = AssetDeposit;
@@ -129,7 +129,7 @@ pub struct TestDaoProvider;
 impl DaoProvider<H256> for TestDaoProvider {
 	type Id = u32;
 	type AccountId = u128;
-	type AssetId = u32;
+	type AssetId = u128;
 	type Policy = DaoPolicy;
 
 	fn exists(_id: Self::Id) -> Result<(), DispatchError> {
@@ -181,7 +181,7 @@ impl pallet_dao_treasury::Config for Test {
 	type WeightInfo = ();
 	type SpendFunds = Bounties;
 	type MaxApprovals = ConstU32<100>;
-	type AssetId = u32;
+	type AssetId = u128;
 	type DaoProvider = TestDaoProvider;
 	type AssetProvider = Assets;
 }
@@ -198,7 +198,7 @@ impl pallet_dao_treasury::Config<Instance1> for Test {
 	type WeightInfo = ();
 	type SpendFunds = Bounties1;
 	type MaxApprovals = ConstU32<100>;
-	type AssetId = u32;
+	type AssetId = u128;
 	type DaoProvider = TestDaoProvider;
 	type AssetProvider = Assets;
 }

--- a/pallets/dao-collective/src/tests.rs
+++ b/pallets/dao-collective/src/tests.rs
@@ -155,7 +155,7 @@ pub struct TestDaoProvider;
 impl DaoProvider<H256> for TestDaoProvider {
 	type Id = u32;
 	type AccountId = u64;
-	type AssetId = u32;
+	type AssetId = u128;
 	type Policy = DaoPolicy;
 
 	fn exists(_id: Self::Id) -> Result<(), DispatchError> {

--- a/pallets/dao-democracy/Cargo.toml
+++ b/pallets/dao-democracy/Cargo.toml
@@ -35,7 +35,7 @@ scale-info = { version = "2.1.1", default-features = false, features = ["derive"
 
 # Local Dependencies
 dao-primitives = { version = "4.0.0-dev", default-features = false, path = "../../primitives/dao" }
-pallet-dao-assets = { version = "4.0.0-dev", default-features = false, path = "../dao-assets" }
+pallet-dao-assets = { version = "4.0.0-dev", default-features = false, git = "https://github.com/sctllabs/societal-node", branch = "main" }
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.32" }

--- a/pallets/dao-democracy/src/lib.rs
+++ b/pallets/dao-democracy/src/lib.rs
@@ -247,7 +247,7 @@ pub mod pallet {
 
 		type Assets: LockableAsset<
 				Self::AccountId,
-				AssetId = u32,
+				AssetId = u128,
 				Moment = Self::BlockNumber,
 				Balance = BalanceOf<Self>,
 			> + Inspect<Self::AccountId>
@@ -333,7 +333,7 @@ pub mod pallet {
 			<Self as frame_system::Config>::Hash,
 			Id = u32,
 			AccountId = Self::AccountId,
-			AssetId = u32,
+			AssetId = u128,
 			Policy = DaoPolicy,
 		>;
 	}
@@ -1617,7 +1617,7 @@ impl<T: Config> Pallet<T> {
 
 	/// Rejig the lock on an account. It will never get more stringent (since that would indicate
 	/// a security hole) but may be reduced from what they are currently.
-	fn update_lock(dao_id: DaoId, who: &T::AccountId, dao_token: DaoToken<u32, Vec<u8>>) {
+	fn update_lock(dao_id: DaoId, who: &T::AccountId, dao_token: DaoToken<u128, Vec<u8>>) {
 		let lock_needed = VotingOf::<T>::mutate(dao_id, who, |voting| {
 			voting.rejig(frame_system::Pallet::<T>::block_number());
 			voting.locked_balance()

--- a/pallets/dao-membership/src/mock.rs
+++ b/pallets/dao-membership/src/mock.rs
@@ -107,7 +107,7 @@ pub struct TestDaoProvider;
 impl DaoProvider<H256> for TestDaoProvider {
 	type Id = u32;
 	type AccountId = u64;
-	type AssetId = u32;
+	type AssetId = u128;
 	type Policy = DaoPolicy;
 
 	fn exists(_id: Self::Id) -> Result<(), DispatchError> {

--- a/pallets/dao-treasury/src/lib.rs
+++ b/pallets/dao-treasury/src/lib.rs
@@ -149,7 +149,7 @@ pub mod pallet {
 			+ MaybeSerializeDeserialize
 			+ MaxEncodedLen
 			+ TypeInfo
-			+ From<u32>
+			+ From<u128>
 			+ Ord;
 
 		/// Origin from which approvals must come.

--- a/pallets/dao-treasury/src/tests.rs
+++ b/pallets/dao-treasury/src/tests.rs
@@ -130,7 +130,7 @@ pub struct TestDaoProvider;
 impl DaoProvider<H256> for TestDaoProvider {
 	type Id = u32;
 	type AccountId = u128;
-	type AssetId = u32;
+	type AssetId = u128;
 	type Policy = DaoPolicy;
 
 	fn exists(_id: Self::Id) -> Result<(), DispatchError> {
@@ -177,7 +177,7 @@ impl Create<AccountId> for TestAssetProvider {
 }
 
 impl Inspect<AccountId> for TestAssetProvider {
-	type AssetId = u32;
+	type AssetId = u128;
 	type Balance = u128;
 
 	fn total_issuance(asset: Self::AssetId) -> Self::Balance {
@@ -293,7 +293,7 @@ impl Transfer<AccountId> for TestAssetProvider {
 impl Config for Test {
 	type PalletId = TreasuryPalletId;
 	type Currency = pallet_balances::Pallet<Test>;
-	type AssetId = u32;
+	type AssetId = u128;
 	type ApproveOrigin = AsEnsureOriginWithArg<frame_system::EnsureRoot<u128>>;
 	type RuntimeEvent = RuntimeEvent;
 	type OnSlash = ();

--- a/pallets/dao/src/lib.rs
+++ b/pallets/dao/src/lib.rs
@@ -155,7 +155,7 @@ pub mod pallet {
 			+ MaybeSerializeDeserialize
 			+ MaxEncodedLen
 			+ TypeInfo
-			+ From<u32>
+			+ From<u128>
 			+ Ord;
 
 		type Balance: Member
@@ -457,7 +457,7 @@ pub mod pallet {
 			let mut has_token_id: Option<AssetId<T>> = None;
 
 			if let Some(token) = token {
-				let token_id = Self::u32_to_asset_id(token.token_id);
+				let token_id = Self::u128_to_asset_id(token.token_id);
 				has_token_id = Some(token_id);
 
 				let metadata = token.metadata;
@@ -509,7 +509,7 @@ pub mod pallet {
 
 			if has_token_id.is_none() {
 				if let Some(id) = token_id {
-					let token_id = Self::u32_to_asset_id(id);
+					let token_id = Self::u128_to_asset_id(id);
 					has_token_id = Some(token_id);
 
 					let issuance =
@@ -601,7 +601,7 @@ pub mod pallet {
 			T::PalletId::get().into_sub_account_truncating(dao_id)
 		}
 
-		fn u32_to_asset_id(asset_id: u32) -> AssetId<T> {
+		fn u128_to_asset_id(asset_id: u128) -> AssetId<T> {
 			asset_id.try_into().ok().unwrap()
 		}
 

--- a/pallets/dao/src/mock.rs
+++ b/pallets/dao/src/mock.rs
@@ -188,7 +188,7 @@ impl Create<AccountId> for TestAssetProvider {
 }
 
 impl Inspect<AccountId> for TestAssetProvider {
-	type AssetId = u32;
+	type AssetId = u128;
 	type Balance = u128;
 
 	fn total_issuance(asset: Self::AssetId) -> Self::Balance {
@@ -303,7 +303,7 @@ impl pallet_dao::Config for Test {
 	type Currency = pallet_balances::Pallet<Test>;
 	type DaoStringLimit = ConstU32<20>;
 	type DaoMetadataLimit = ConstU32<20>;
-	type AssetId = u32;
+	type AssetId = u128;
 	type Balance = u128;
 	type CouncilProvider = TestCouncilProvider;
 	type AssetProvider = TestAssetProvider;

--- a/primitives/dao/src/lib.rs
+++ b/primitives/dao/src/lib.rs
@@ -51,7 +51,7 @@ pub struct DaoTokenMetadata {
 	Encode, Decode, Default, Clone, PartialEq, TypeInfo, RuntimeDebug, Serialize, Deserialize,
 )]
 pub struct DaoGovernanceToken {
-	pub token_id: u32,
+	pub token_id: u128,
 	pub metadata: DaoTokenMetadata,
 	#[serde(default)]
 	#[serde(deserialize_with = "de_option_string_to_u128")]
@@ -70,7 +70,7 @@ pub struct DaoPayload {
 	#[serde(deserialize_with = "de_string_to_bytes")]
 	pub metadata: Vec<u8>,
 	pub token: Option<DaoGovernanceToken>,
-	pub token_id: Option<u32>,
+	pub token_id: Option<u128>,
 	#[serde(default)]
 	#[serde(deserialize_with = "de_option_string_to_bytes")]
 	pub token_address: Option<Vec<u8>>,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -115,7 +115,7 @@ hex-literal = { version = "0.3.4", optional = true }
 # Local Dependencies
 eth-primitives = { version = "4.0.0-dev", default-features = false, path = "../primitives/eth" }
 pallet-dao = { version = "4.0.0-dev", default-features = false, path = "../pallets/dao" }
-pallet-dao-assets = { version = "4.0.0-dev", default-features = false, path = "../pallets/dao-assets" }
+pallet-dao-assets = { version = "4.0.0-dev", default-features = false, git = "https://github.com/sctllabs/societal-node", branch = "main" }
 pallet-dao-bounties = { version = "4.0.0-dev", default-features = false, path = "../pallets/dao-bounties" }
 pallet-dao-collective = { version = "4.0.0-dev", default-features = false, path = "../pallets/dao-collective" }
 pallet-dao-collective-precompile = { version = "1.0.0-dev", default-features = false, path = "../precompiles/dao-collective" }
@@ -129,6 +129,7 @@ pallet-dao-precompile = { version = "1.0.0-dev", default-features = false, path 
 pallet-dao-treasury = { version = "4.0.0-dev", default-features = false, path = "../pallets/dao-treasury" }
 pallet-dao-treasury-precompile = { version = "1.0.0-dev", default-features = false, path = "../precompiles/dao-treasury" }
 # From Moonbeam
+pallet-evm-precompileset-assets-erc20 = { version = "0.1.0", default-features = false, git = "https://github.com/sctllabs/moonbeam.git", branch = "moonbeam-polkadot-v0.9.32-asset-manager" }
 precompile-utils = { version = "0.1.0", default-features = false, git = "https://github.com/sctllabs/moonbeam.git", branch = "moonbeam-polkadot-v0.9.32" }
 
 [build-dependencies]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -681,7 +681,7 @@ impl pallet_treasury::Config for Runtime {
 	type SpendOrigin = frame_support::traits::NeverEnsureOrigin<u128>;
 }
 
-pub type AssetId = u32;
+pub type AssetId = u128;
 
 impl pallet_dao_treasury::Config for Runtime {
 	type PalletId = DaoTreasuryPalletId;


### PR DESCRIPTION
- integrated assets-erc20 precompile from moonbeam
- using u128 as asset id


Custom changes for moonbeam precompiles in the [forked repo](https://github.com/sctllabs/moonbeam/commits/moonbeam-polkadot-v0.9.32-asset-manager):

 